### PR TITLE
remove toLowerCase to allow for camelcase svg tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = postcss.plugin('postcss-write-svg', function () {
 
 	function createXML(node) {
 		var selector   = node.selector;
-		var tagName    = selector ? selector.toLowerCase() : 'svg';
+		var tagName    = selector ? selector : 'svg';
 		var attributes = selector ? {} : { xmlns: 'http://www.w3.org/2000/svg' };
 		var childNodes = node.nodes;
 		var innerXML   = '';


### PR DESCRIPTION
Removed the `.toLowerCase` from the `tagName` assignment to allow for use of camelCase svg elements, e.g. `<feGaussianBlur>` or `<linearGradient>`
